### PR TITLE
Easy to use default constructors for primitive types

### DIFF
--- a/SDL2.cs
+++ b/SDL2.cs
@@ -3961,6 +3961,29 @@ namespace SDL2
 			public byte g;
 			public byte b;
 			public byte a;
+
+			public SDL_Color() { r = 0; g = 0; b = 0; a = 0; }
+			public SDL_Color(byte r, byte g, byte b)
+			{
+				this.r = r;
+				this.g = g;
+				this.b = b;
+				this.a = 255;
+			}
+			public SDL_Color(byte a, byte r, byte g, byte b)
+			{
+				this.r = r;
+				this.g = g;
+				this.b = b;
+				this.a = a;
+			}
+			public SDL_Color(byte a, SDL_Color color)
+			{
+				this.r = color.r;
+				this.g = color.g;
+				this.b = color.b;
+				this.a = a;
+			}
 		}
 
 		[StructLayout(LayoutKind.Sequential)]
@@ -4113,6 +4136,14 @@ namespace SDL2
 		{
 			public int x;
 			public int y;
+
+			public SDL_Point() { x = 0; y = 0; }
+
+			public SDL_Point(int x, int y)
+			{
+				this.x = x;
+				this.y = y;
+			}
 		}
 
 		[StructLayout(LayoutKind.Sequential)]
@@ -4122,6 +4153,16 @@ namespace SDL2
 			public int y;
 			public int w;
 			public int h;
+
+			public SDL_Rect() { x = 0; y = 0; w = 0; h = 0; }
+
+			public SDL_Rect(int x, int y, int width, int height)
+			{
+				this.x = x;
+				this.y = y;
+				this.w = width;
+				this.h = height;
+			}
 		}
 
 		/* Only available in 2.0.10 or higher. */
@@ -4130,16 +4171,33 @@ namespace SDL2
 		{
 			public float x;
 			public float y;
-		}
 
-		/* Only available in 2.0.10 or higher. */
-		[StructLayout(LayoutKind.Sequential)]
+			public SDL_FPoint() { x = 0.0f; y = 0.0f; }
+            public SDL_FPoint(float x, float y)
+            {
+				this.x = x;
+				this.y = y;
+			}
+        }
+
+        /* Only available in 2.0.10 or higher. */
+        [StructLayout(LayoutKind.Sequential)]
 		public struct SDL_FRect
 		{
 			public float x;
 			public float y;
 			public float w;
 			public float h;
+
+			public SDL_FRect() { x = 0.0f; y = 0.0f; w = 0.0f; h = 0.0f; }
+
+			public SDL_FRect(float x, float y, float width, float height)
+			{
+				this.x = x;
+				this.y = y;
+				this.w = width;
+				this.h = height;
+			}
 		}
 
 		/* Only available in 2.0.4 or higher. */


### PR DESCRIPTION
Easy to use default constructors added for SDL_Color, SDL_Rect, SDL_Point, SDL_FRect, SDL_FPoint